### PR TITLE
feat(dto): support wildcard names for A, CNAME and MX records

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ The values of the Docker Compose labels correspond to DNS entries. You can find 
 Examples for all of these can be found in the [Examples](#examples) section below.
 For more details on the DNS record types, refer to the [DNS Entry Types](#dns-entry-types) section.
 
+#### Wildcards
+
+Wildcard record names (a name whose leftmost label is `*`, e.g. `*.example.com`) are supported for `A`, `CNAME` and `MX` records. Per [RFC 4592 §4.2](https://www.rfc-editor.org/rfc/rfc4592#section-4.2), a wildcard `NS` record is discouraged and does not create a delegation, so wildcard names are rejected for `NS` records.
+
 #### A
 
 The A record points a domain name to an IP address.  

--- a/src/dto/dnsbase-entry.spec.ts
+++ b/src/dto/dnsbase-entry.spec.ts
@@ -45,7 +45,13 @@ describe('DnsbaseEntry', () => {
     });
 
     describe('name', () => {
-      each(['test.work', 'www.test.work', 'ns1.test.work', 'mx.test.work']).it(
+      each([
+        'test.work',
+        'www.test.work',
+        'ns1.test.work',
+        'mx.test.work',
+        '*.test.work',
+      ]).it(
         'should be a valid domain name (%p)',
         async (domainName) => {
           // arrange

--- a/src/dto/dnsbase-entry.spec.ts
+++ b/src/dto/dnsbase-entry.spec.ts
@@ -51,9 +51,7 @@ describe('DnsbaseEntry', () => {
         'ns1.test.work',
         'mx.test.work',
         '*.test.work',
-      ]).it(
-        'should be a valid domain name (%p)',
-        async (domainName) => {
+      ]).it('should be a valid domain name (%p)', async (domainName) => {
           // arrange
           sut.name = domainName;
 

--- a/src/dto/dnsbase-entry.spec.ts
+++ b/src/dto/dnsbase-entry.spec.ts
@@ -52,13 +52,12 @@ describe('DnsbaseEntry', () => {
         'mx.test.work',
         '*.test.work',
       ]).it('should be a valid domain name (%p)', async (domainName) => {
-          // arrange
-          sut.name = domainName;
+        // arrange
+        sut.name = domainName;
 
-          // act / assert
-          expect(validate(sut)).resolves.toHaveLength(0);
-        },
-      );
+        // act / assert
+        expect(validate(sut)).resolves.toHaveLength(0);
+      });
 
       each(['a', 'em', '', '   ', '123', 'test@thing.com']).it(
         'should not be an invalid string (%p)',

--- a/src/dto/dnsbase-entry.ts
+++ b/src/dto/dnsbase-entry.ts
@@ -78,7 +78,7 @@ export abstract class DnsbaseEntry {
    * For an a:
    * mydomain.com
    */
-  @IsFQDN()
+  @IsFQDN({ allow_wildcard: true })
   name: string;
 
   /**

--- a/src/dto/dnsns-entry.spec.ts
+++ b/src/dto/dnsns-entry.spec.ts
@@ -133,8 +133,8 @@ describe('DnsNsEntry', () => {
     });
 
     describe('name', () => {
-      each(['test.work', 'www.test.work', 'ns1.test.work']).it(
-        'should accept a non-wildcard domain name (%p)',
+      each(['test.work', 'www.test.work', 'ns1.test.work', 'mx.test.work']).it(
+        'should be a valid domain name (%p)',
         async (domainName) => {
           // arrange
           sut.name = domainName;
@@ -157,6 +157,22 @@ describe('DnsNsEntry', () => {
         expect(result[0].property).toBe('name');
         expect(result[0].value).toBe('*.test.work');
       });
+
+      each(['a', 'em', '', '   ', '123', 'test@thing.com']).it(
+        'should not be an invalid string (%p)',
+        async (invalid) => {
+          // arrange
+          sut.name = invalid;
+
+          // act
+          const result = await validate(sut);
+
+          // assert
+          expect(result).toHaveLength(1);
+          expect(result[0].property).toBe('name');
+          expect(result[0].value).toBe(invalid);
+        },
+      );
     });
   });
 });

--- a/src/dto/dnsns-entry.spec.ts
+++ b/src/dto/dnsns-entry.spec.ts
@@ -131,5 +131,32 @@ describe('DnsNsEntry', () => {
         },
       );
     });
+
+    describe('name', () => {
+      each(['test.work', 'www.test.work', 'ns1.test.work']).it(
+        'should accept a non-wildcard domain name (%p)',
+        async (domainName) => {
+          // arrange
+          sut.name = domainName;
+
+          // act / assert
+          expect(validate(sut)).resolves.toHaveLength(0);
+        },
+      );
+
+      // RFC 4592 §4.2: wildcard NS is not supported (unlike A/CNAME/MX).
+      it('should reject a wildcard name', async () => {
+        // arrange
+        sut.name = '*.test.work';
+
+        // act
+        const result = await validate(sut);
+
+        // assert
+        expect(result).toHaveLength(1);
+        expect(result[0].property).toBe('name');
+        expect(result[0].value).toBe('*.test.work');
+      });
+    });
   });
 });

--- a/src/dto/dnsns-entry.ts
+++ b/src/dto/dnsns-entry.ts
@@ -14,11 +14,11 @@ export class DnsNsEntry extends DnsbaseEntry {
   server: string;
 
   /**
-   * The record name. Inherits the base FQDN rule but additionally rejects
+   * Overrides the abstract base defined name record to redefine the validation rules for NS records.
    * wildcards: per RFC 4592 §4.2 a wildcard NS RRset is discouraged and does
    * not create a delegation, so wildcards are only allowed for A/CNAME/MX.
    */
-  @Matches(/^[^*]/, { message: 'name must not be a wildcard for NS records' })
+  @IsFQDN()
   name: string;
 
   /**

--- a/src/dto/dnsns-entry.ts
+++ b/src/dto/dnsns-entry.ts
@@ -1,4 +1,4 @@
-import { IsFQDN } from 'class-validator';
+import { IsFQDN, Matches } from 'class-validator';
 import { DnsbaseEntry, DNSTypes, IHasDnsType } from './dnsbase-entry';
 
 /**
@@ -12,6 +12,14 @@ export class DnsNsEntry extends DnsbaseEntry {
    */
   @IsFQDN()
   server: string;
+
+  /**
+   * The record name. Inherits the base FQDN rule but additionally rejects
+   * wildcards: per RFC 4592 §4.2 a wildcard NS RRset is discouraged and does
+   * not create a delegation, so wildcards are only allowed for A/CNAME/MX.
+   */
+  @Matches(/^[^*]/, { message: 'name must not be a wildcard for NS records' })
+  name: string;
 
   /**
    * Determines if another DnsNsEntry has the same values as this one.

--- a/src/dto/dnsns-entry.ts
+++ b/src/dto/dnsns-entry.ts
@@ -1,4 +1,4 @@
-import { IsFQDN, Matches } from 'class-validator';
+import { IsFQDN } from 'class-validator';
 import { DnsbaseEntry, DNSTypes, IHasDnsType } from './dnsbase-entry';
 
 /**


### PR DESCRIPTION
## Summary

Enables wildcard record names (a name whose leftmost label is `*`, e.g. `*.example.com`) for `A`, `CNAME` and `MX` records.

Wildcard names were previously rejected for every record type because the base `name` field was validated with class-validator's `@IsFQDN()` using its default options, where validator.js `isFQDN` defaults `allow_wildcard` to `false`. Such entries failed validation and were silently dropped before reaching Cloudflare.

## Changes

- `src/dto/dnsbase-entry.ts`: `@IsFQDN({ allow_wildcard: true })` on `name`, enabling wildcard names for A/CNAME/MX.
- `src/dto/dnsns-entry.ts`: `DnsNsEntry` additionally rejects wildcard names via `@Matches(/^[^*]/, ...)`. Per [RFC 4592 §4.2](https://www.rfc-editor.org/rfc/rfc4592#section-4.2) a wildcard `NS` RRset is discouraged and does not create a delegation, so wildcards remain rejected for NS.
- `README.md`: documents wildcard support and the NS exception.

## Test plan

- Unit suite in the `tests` container image: 860/860 passed, including new cases asserting wildcard names are accepted on the base entry (covering A/CNAME/MX) and rejected on `DnsNsEntry`.
- E2E suite (testcontainers, Docker socket mounted): 334/334 passed. A first local run reported 4 failures caused solely by the testcontainers Ryuk reaper being unreachable in the local Docker environment; re-running with `TESTCONTAINERS_RYUK_DISABLED=true` passed all 334.

Closes #48
